### PR TITLE
we need to be consistent with runc container state

### DIFF
--- a/contrib/hook.json
+++ b/contrib/hook.json
@@ -9,6 +9,6 @@
         }
     },
     "stages": [
-        "prestart"
+        "poststart"
     ]
 }

--- a/contrib/hook.sh
+++ b/contrib/hook.sh
@@ -6,8 +6,11 @@ set -x
 
 CG_PATH=$(jq -er '.linux.cgroupsPath' < config.json)
 
-if [[ "$CG_PATH" = *burst* ]];
+if [[ "$CG_PATH" =~ .*"burst".* ]];
 then
   CONTAINERID=$(jq -er '.linux.cgroupsPath | split(":")[2]' < config.json)
-  echo max > /sys/fs/cgroup/kubepods.slice/*burst*/*/crio-$CONTAINERID*/memory.swap.max
+  runc update $CONTAINERID --memory-swap -1
 fi
+
+
+


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

in terms of resource configuration. Therefore use
runc in order to update the container state with swap max.

the issue arose when CPU manager was enabled and resource update was triggered by kubelet, the swap max value was restore to 0.

In addition there was a need to switch to post-start hook phase since in the pre-start phase runc still doesn't created the container state.