### PR TITLE
docs: improve swap space calculation example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,13 +61,12 @@ $ oc adm policy add-scc-to-user -n wasp privileged -z wasp
 > The amount of swap space to be provisioned on a node must
 > be calculated according to the following formula:
 >
->     NODE_SWAP_SPACE = NODE_RAM * MEMORY_OVER_COMMIT_RATIO
+>     NODE_SWAP_SPACE = (NODE_RAM * MEMORY_OVER_COMMIT_PERCENTAGE) - NODE_RAM
 >
-> Example:
+> Example (overcommit percentage is always > 100%):
 >
->     NODE_SWAP_SPACE = 16 GB * 150%
->                     = 16 GB * 0.5
->                     =  8 GB
+>     NODE_SWAP_SPACE = (16 GB * 150/100) - 16 GB = 24 GB - 16 GB = 8 GB
+>
 
    Create a `MachineConfig` according to the following
    [example](../manifests/machineconfig-add-swap.yaml).


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com

since we use percentage units for overcommit, use the same units in the example. Also since its about overcommit, the percentage is always higher than 100%