### PR TITLE
Update documentation

### DIFF
--- a/manifests/machineconfig-add-swap.yaml
+++ b/manifests/machineconfig-add-swap.yaml
@@ -18,7 +18,12 @@ spec:
           [Service]
           Type=oneshot
           Environment=SWAP_SIZE_MB=5000
-          ExecStart=/bin/sh -c "sudo dd if=/dev/zero of=/var/tmp/swapfile count=$SWAP_SIZE_MB bs=1MiB && sudo chmod 600 /var/tmp/swapfile && sudo mkswap /var/tmp/swapfile && sudo swapon /var/tmp/swapfile && free -h"
+          ExecStart=/bin/sh -c "sudo dd if=/dev/zero of=/var/tmp/swapfile count=${SWAP_SIZE_MB} bs=1M && \
+          sudo chmod 600 /var/tmp/swapfile && \
+          sudo mkswap /var/tmp/swapfile && \
+          sudo swapon /var/tmp/swapfile && \
+          free -h && \
+          sudo systemctl set-property --runtime system.slice MemorySwapMax=0 IODeviceLatencyTargetSec=\"/ 50ms\""      
           
           [Install]
           RequiredBy=kubelet-dependencies.target


### PR DESCRIPTION
To recommend setting system.slice cgroup configurations in the machineConfig object. It's best to keep all these settings centralized there, as Kubernetes doesn't handle them directly. The Wasp agent should also avoid making these changes to align with Kubernetes' behavior.
This update ensures users won't need separate machine configurations after upgrades.