### PR TITLE
Add Documentation for Installing and Configuring Wasp, Including Upgrade Path from v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,30 +15,30 @@ The design can be found in https://github.com/openshift/enhancements/pull/1630
 - Disable swap in the system.slice
 
 ## Wasp Agent: configuring Kubernetes containers
-- Install an OCI hook to enable swap, setting swap=max for every burstable virt-launcher pod.
-
-### Future plans
 - Set a specific amount of swap for each burstable pod to match Kubernetes limited swap settings.
+
+**Please note:** swap configuration will not be done for static pods, mirror pods, or critical system pods based on pod priority.
+
+### Pod selection for eviction
+- Eviction targets non-static pods, mirror pods, or critical system pods based on pod priority.
+  Pods in namespaces beginning with "openshift" or "kube-system" are excluded from eviction.
 
 ## Eviction
 
 ### Swap based eviction signals
-- Utilization - How close are we to run out of swap? (WIP - maybe kubernetes built in signal is good enough)
+- Utilization - How close are we to run out of swap?
 - Traffic - How badly is swapping affecting the system?
 - Overcommit ratio - How over committed is the system?
 
 ### Pod selection for eviction
-- Eviction targets non-static pods, mirror pods, or critical system pods based on pod priority. 
+- Eviction doesn't target static pods, mirror pods, or critical system pods based on pod priority.
   Pods in namespaces beginning with "openshift" or "kube-system" are excluded from eviction.
-- Currently, a "basic" implementation prioritizes pods with "memory" substring in their name.
 
-#### Future plan
-
-- Eviction order:
-  - Exceeding memory resource limits
-  - Exceeding resource requests 
-  - Pod Priority
-  - The pod's resource usage relative to requests
+### Eviction order:
+- Exceeding memory resource limits
+- Exceeding resource requests
+- Pod Priority
+- The pod's resource usage relative to requests
 
 Note: This is inspired by the [Kubernetes eviction order](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction)
 , with an additional first criterion.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Wasp agent implmenetes the same policy as `swapBehavior: LimitedSwap` in kuberne
 
 ### Pod selection for eviction
 - Eviction doesn't target static pods, mirror pods, or critical system pods based on pod priority.
-  Pods in namespaces beginning with "openshift" or "kube-system" are excluded from eviction.
 
 ### Eviction order:
 - Exceeding memory resource limits

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ $ # Openshift Pre-requisits
 $ #
 $ # Note: KubeletConfig CRs are mutually exclusive
 $ oc create -f manifests/openshift/kubelet-configuration-with-swap.yaml
-$ oc wait mcp worker --for condition=Updated=True --timeout=300s
+$ oc wait mcp worker --for condition=Updated=True --timeout=-1s
 $ oc create -f manifests/openshift/machine-config-add-swap.yaml
-$ oc wait mcp worker --for condition=Updated=True --timeout=300s
+$ oc wait mcp worker --for condition=Updated=True --timeout=-1s
 $ #
 $ # WASP deployment
 $ #

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,163 @@
+# Configuring higher workload density
+
+You can configure a higher VM workload and pod workload density in your cluster 
+by over-committing memory resources (RAM).
+
+While over-committed memory can lead to a higher workload density, at
+the same time this will lead to some side-effects:
+
+- Lower workload performance on a highly utilized system
+
+Some workloads are more suited for higher workload density than
+others, for example:
+
+- Many similar workloads
+- Underutilized workloads
+
+## Configuring higher workload density with the wasp-agent
+
+[wasp-agent]  is a component that enables an OpenShift cluster to assign 
+SWAP resources to burstable pod and VM workloads. Additionally, wasp-agent 
+is responsible for managing pod evictions when the system is heavily loaded and nodes are at risk.
+
+SWAP usage is supported on worker nodes only.
+
+### Prerequisites
+
+* `oc` is available
+* Logged into cluster with `cluster-admin` role
+* A defined memory over-commit ratio. By default: 150%
+* A worker pool
+
+### Procedure
+
+> [!NOTE]
+> The `wasp-agent` will deploy an OCI hook and periodically 
+> verifies the swap limit to ensure it is set correctly in order to enable
+> swap usage for containers on the node level.
+> The low-level nature requires the `DaemonSet` to be privileged.
+
+1. Configure `Kubelet` to permit swap
+   Create a `KubeletConfiguration` according to the following
+   [example](../manifests/openshift/kubelet-configuration-with-swap.yaml).
+
+2. Create `MachineConfig` to provision swap according to the following [example](../manifests/openshift/machineconfig-add-swap.yaml)
+
+> [!IMPORTANT]
+> In order to have enough swap for the worst case scenario, it must
+> be ensured to have at least as much swap space provisioned as RAM
+> is being over-committed.
+> The amount of swap space to be provisioned on a node must
+> be calculated according to the following formula:
+>
+>     NODE_SWAP_SPACE = NODE_RAM * (MEMORY_OVER_COMMIT_PERCENT / 100% - 1)
+>
+> Example:
+>
+>     NODE_SWAP_SPACE = 16 GB * (150% / 100% - 1)
+>                     = 16 GB * (1.5 - 1)
+>                     = 16 GB * (0.5)
+>                     =  8 GB
+
+Create a `MachineConfig` according to the following
+[example](../manifests/openshift/machineconfig-add-swap.yaml).
+
+3. Create a privileged service account:
+
+```console
+$ oc adm new-project wasp
+$ oc create sa -n wasp wasp
+$ oc create clusterrolebinding wasp --clusterrole=cluster-admin --serviceaccount=wasp:wasp
+$ oc adm policy add-scc-to-user -n wasp privileged -z wasp
+```
+
+4. Deploy `wasp-agent`
+   Create a `DaemonSet` according to the following
+   [example](../manifests/openshift/ds.yaml).
+
+> [!IMPORTANT]
+> The wasp-agent  manages pod eviction when the system is heavily loaded and
+> nodes are at risk. Eviction will be triggered if any of the following conditions occur:
+> 1. High Swap I/O Traffic:
+> * `averageSwapInPerSecond > maxAverageSwapInPagesPerSecond`
+> and<br>
+> `averageSwapOutPerSecond > maxAverageSwapOutPagesPerSecond`<br><br>
+> This condition is triggered when swap-related I/O traffic
+> is excessively high.
+> The default values for `maxAverageSwapInPagesPerSecond` and
+> `maxAverageSwapOutPagesPerSecond` are both set to 1000, averaged 
+> over a 30-second interval by default.
+> 2. High Memory Overcommitment:
+> * `maxMemoryOverCommitmentBytes < SwapUsedBytes - AvailableMemoryBytes`<br><br>
+> This condition is triggered when swap utilization is excessively high.
+> This depends on the `NODE_SWAP_SPACE` setting in the machine configuration from
+> step 3 or when the memory overcommitment ratio is too high.The default value for
+> `maxMemoryOverCommitment` is set to 500Mi.<br><br>
+>
+> `maxAverageSwapInPagesPerSecond`, `maxAverageSwapOutPagesPerSecond`, and 
+> `maxMemoryOverCommitment` can be adjusted by modifying the values of the 
+> `MAX_AVERAGE_SWAP_IN_PAGES_PER_SECOND`, `MAX_AVERAGE_SWAP_OUT_PAGES_PER_SECOND`, 
+> and `MEMORY_OVER_COMMITMENT_THRESHOLD` environment variables in the provided 
+> example, respectively. Additionally, the `AVERAGE_WINDOW_SIZE_SECONDS` environment 
+> variable determines the time frame for calculating the average.
+
+5. Deploy alerting rules according to the following
+   [example](../manifests/openshift/prometheus-rules.yaml) and
+   add the cluster-monitoring label to the wasp namespace.
+```console
+$ oc label namespace wasp openshift.io/cluster-monitoring="true"
+```
+
+6. Configure OpenShift Virtualization to use memory overcommit using
+
+   a. the OpenShift Console
+   b. the following [HCO example](../manifests/openshift/hco-set-memory-overcommit.yaml):
+
+```console
+$ oc patch --type=merge \
+  -f <../manifests/hco-set-memory-overcommit.yaml> \
+  --patch-file <../manifests/hco-set-memory-overcommit.yaml>
+```
+
+> [!NOTE]
+> After applying all configurations all `MachineConfigPool`
+> roll-outs have to complete before the feature is fully available.
+>
+>     $ oc wait mcp worker --for condition=Updated=True
+>
+
+### Verification
+
+1. Validate the deployment
+   TBD
+2. Validate correctly provisioned swap by running:
+
+       $ oc get nodes -l node-role.kubernetes.io/worker
+       # Select a node from the provided list
+
+       $ oc debug node/<selected-node> -- free -m
+
+   Should show an amoutn larger than zero for swap, similar to:
+
+                      total        used        free      shared  buff/cache   available
+       Mem:           31846       23155        1044        6014       14483        8690
+       Swap:           8191        2337        5854
+
+
+3. Validate OpenShift Virtualization memory overcommitment configuration
+   by running:
+
+       $ oc get -n openshift-cnv HyperConverged kubevirt-hyperconverged -o jsonpath="{.spec.higherWorkloadDensity.memoryOvercommitPercentage}"
+       150
+
+   The returned value (in this case `150`) should match the value you
+   have configured earlier on.
+
+4. Validate Virtual Machine memory overcommitment
+   TBD
+
+### Additional Resources
+
+[wasp-agent]: https://github.com/openshift-virtualization/wasp-agent
+FPR: Free-Page Reporting
+KSM:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,25 @@ $ oc patch --type=merge \
 >     $ oc wait mcp worker --for condition=Updated=True
 >
 
+### Upgrade path
+For users of wasp-agent v1.0, which lacks LimitedSwap and eviction support, here is the upgrade path:
+1. Adjust KubeletConfig:
+   If you have installed the KubeletConfiguration object from version v1.0, you need to update it. 
+   This can be done by applying the updated [KubeletConfiguration example](../manifests/openshift/kubelet-configuration-with-swap.yaml).
+```console
+$ oc replace -f <../manifests/openshift/kubelet-configuration-with-swap.yaml>
+```
+2. Update DaemonSet:
+   Apply the updated DaemonSet by using the provided [DaemonSet example](../manifests/openshift/ds.yaml).
+```console
+$ oc apply -f <../manifests/openshift/ds.yaml>
+```
+3. Update monitoring object:
+```console
+$ oc delete AlertingRule wasp-alerts -nopenshift-monitoring
+$ oc create -f <../manifests/openshift/prometheus-rule.yaml>
+```
+
 ### Verification
 
 1. Validate the deployment

--- a/manifests/openshift/ds.yaml
+++ b/manifests/openshift/ds.yaml
@@ -1,0 +1,70 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: wasp-agent
+  namespace: wasp
+  labels:
+    app: wasp
+    tier: node
+spec:
+  selector:
+    matchLabels:
+      name: wasp
+  template:
+    metadata:
+      annotations:
+        description: >-
+          Configures swap for workloads
+      labels:
+        name: wasp
+    spec:
+      containers:
+        - env:
+            - name: MEMORY_OVER_COMMITMENT_THRESHOLD
+              value: 500Mi
+            - name: MAX_AVERAGE_SWAP_IN_PAGES_PER_SECOND
+              value: "1000"
+            - name: MAX_AVERAGE_SWAP_OUT_PAGES_PER_SECOND
+              value: "1000"
+            - name: AVERAGE_WINDOW_SIZE_SECONDS
+              value: "30"
+            - name: VERBOSITY
+              value: "1"
+            - name: FSROOT
+              value: /host
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: >-
+            quay.io/openshift-virtualization/wasp-agent:v4.17
+          imagePullPolicy: Always
+          name: wasp-agent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 50M
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /host
+              name: host
+            - mountPath: /rootfs
+              name: rootfs
+      hostPID: true
+      hostUsers: true
+      priorityClassName: system-node-critical
+      serviceAccountName: wasp
+      terminationGracePeriodSeconds: 5
+      volumes:
+        - hostPath:
+            path: /
+          name: host
+        - hostPath:
+            path: /
+          name: rootfs
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+      maxSurge: 0

--- a/manifests/openshift/ds.yaml
+++ b/manifests/openshift/ds.yaml
@@ -20,8 +20,8 @@ spec:
     spec:
       containers:
         - env:
-            - name: MEMORY_OVER_COMMITMENT_THRESHOLD
-              value: 500Mi
+            - name: SWAP_UTILIZATION_THRESHOLD_FACTOR
+              value: 0.8
             - name: MAX_AVERAGE_SWAP_IN_PAGES_PER_SECOND
               value: "1000"
             - name: MAX_AVERAGE_SWAP_OUT_PAGES_PER_SECOND


### PR DESCRIPTION
This PR introduces  documentation for the installation and configuration of Wasp. The new docs are based on the v1.0 documentation and have been updated to reflect the Go rewrite. They also include the newly added eviction logic and limited swap features in the wasp-agent.

Additionally, the PR includes an upgrade path for users transitioning from wasp-agent v1.0, which lacked LimitedSwap and eviction support. The upgrade instructions detail the necessary adjustments to the KubeletConfig object and the application of the updated DaemonSet.

The README file has also been updated to reflect the new eviction and limited swap functionalities.

NOTE: we need to make sure the right tag is being used in the ds yaml and that the upgrade path does work.

