### PR TITLE
Adding OWNERS and OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - code-reviewers
+approvers:
+  - approvers
+emeritus_approvers:
+  - emeritus_approvers
+  

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,9 @@
+aliases:
+  approvers:
+  - fabiand
+  - barakmor1
+  - enp0s3
+  code-reviewers:
+  - fabiand
+  - barakmor1
+  - enp0s3


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

In order to comply to Openshift-CI dev cycle, and to Prow in general, adding OWNERS and OWNERS_ALIASES

Prow plugins will use these files, thus establishing the k8s styke workflow of reviews and approves of a PR.

In addition these files will be mirrored to Openshift/release repo where the openshift-ci configuration will reside.