### PR TITLE
oci-hook: exclude kube-system burstable pods from swapping

### DIFF
--- a/OCI-hook/hook.sh
+++ b/OCI-hook/hook.sh
@@ -7,7 +7,7 @@ set -x
 CG_PATH=$(jq -er '.linux.cgroupsPath' < config.json)
 POD_NAMESPACE=$(jq -er '.annotations["io.kubernetes.pod.namespace"]' < config.json)
 
-if [[ "$CG_PATH" =~ .*"burst".* && ! "$POD_NAMESPACE" =~ "openshift".* ]];
+if [[ "$CG_PATH" =~ .*"burst".* && ! "$POD_NAMESPACE" =~ "openshift".* && ! "$POD_NAMESPACE" =~ "kube-system".* ]];
 then
   CONTAINERID=$(jq -er '.linux.cgroupsPath | split(":")[2]' < config.json)
   runc update $CONTAINERID --memory-swap -1


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>