### PR TITLE
Remove namespace based exclusion in swap and eviction 

### DIFF
--- a/OCI-hook/hook.sh
+++ b/OCI-hook/hook.sh
@@ -7,7 +7,7 @@ set -x
 CG_PATH=$(jq -er '.linux.cgroupsPath' < config.json)
 POD_NAMESPACE=$(jq -er '.annotations["io.kubernetes.pod.namespace"]' < config.json)
 
-if [[ "$CG_PATH" =~ .*"burst".* && ! "$POD_NAMESPACE" =~ "openshift".* && ! "$POD_NAMESPACE" =~ "kube-system".* ]];
+if [[ "$CG_PATH" =~ .*"burst".* ]];
 then
   CONTAINERID=$(jq -er '.linux.cgroupsPath | split(":")[2]' < config.json)
   runc update $CONTAINERID --memory-swap -1

--- a/pkg/wasp/limited-swap-manager/limited-swap-manager.go
+++ b/pkg/wasp/limited-swap-manager/limited-swap-manager.go
@@ -178,9 +178,8 @@ func (lsm *LimitedSwapManager) execute(key string) (error, enqueueState) {
 		log.Log.Errorf(err.Error())
 		return err, BackOff
 	}
-	excludedPrefixesForNamespaces := []string{"openshift", "kube-system"}
 	podQos := kubeapiqos.GetPodQOS(pod)
-	setAllContainersSwapToZero := podQos != v1.PodQOSBurstable || kubelettypes.IsCriticalPod(pod) || hasExcludedPrefix(pod.Namespace, excludedPrefixesForNamespaces)
+	setAllContainersSwapToZero := podQos != v1.PodQOSBurstable || kubelettypes.IsCriticalPod(pod)
 
 	for _, container := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
 		containerState, exist := getContainerState(pod, container)
@@ -321,14 +320,4 @@ func getContainerState(pod *v1.Pod, container v1.Container) (v1.ContainerState, 
 	}
 
 	return v1.ContainerState{}, false
-}
-
-// hasExcludedPrefix checks if the given namespace name starts with any of the excluded prefixes
-func hasExcludedPrefix(namespace string, excludedPrefixes []string) bool {
-	for _, prefix := range excludedPrefixes {
-		if strings.HasPrefix(namespace, prefix) {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/wasp/pod-filter/pod-filter.go
+++ b/pkg/wasp/pod-filter/pod-filter.go
@@ -1,8 +1,6 @@
 package pod_filter
 
 import (
-	"strings"
-
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -25,25 +23,12 @@ func NewPodFilterImpl(waspNs string) *PodFilterImpl {
 func (pr *PodFilterImpl) FilterPods(pods []*v1.Pod) []*v1.Pod {
 	var filteredPods []*v1.Pod
 
-	// Prefixes to exclude
-	excludedPrefixesForNamespaces := []string{"openshift", "kube-system"}
-
 	for _, pod := range pods {
 		// Check if the namespace name starts with any of the excluded prefixes
-		if pod.Namespace != pr.waspNs && !pr.hasExcludedPrefix(pod.Namespace, excludedPrefixesForNamespaces) && !IsCriticalPod(pod) {
+		if pod.Namespace != pr.waspNs && !IsCriticalPod(pod) {
 			filteredPods = append(filteredPods, pod)
 		}
 	}
 
 	return filteredPods
-}
-
-// hasExcludedPrefix checks if the given namespace name starts with any of the excluded prefixes
-func (pr *PodFilterImpl) hasExcludedPrefix(namespace string, excludedPrefixes []string) bool {
-	for _, prefix := range excludedPrefixes {
-		if strings.HasPrefix(namespace, prefix) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

Since we want to be aligned with upstream Kubernetes implementation of swap, we will not exclude pods
based on their namespace prefixes.

