### PR TITLE
Prevent nil pointer dereference while collecting pod and container stats

### DIFF
--- a/pkg/wasp/stats-collector/pod_stats_collector.go
+++ b/pkg/wasp/stats-collector/pod_stats_collector.go
@@ -244,9 +244,14 @@ func (psc *PodStatsCollectorImpl) ListPodsSummary() ([]PodSummary, error) {
 			podStats.ProcessStats = cadvisorInfoToProcessStats(podInfo)
 			if podStats.Memory != nil {
 				psc.PodSummary[string(podUID)].MemoryWorkingSetBytes = podStats.Memory.WorkingSetBytes
+			} else {
+				psc.PodSummary[string(podUID)].MemoryWorkingSetBytes = uint64Ptr(0)
 			}
+
 			if podStats.Swap != nil {
 				psc.PodSummary[string(podUID)].MemorySwapCurrentBytes = podStats.Swap.SwapUsageBytes
+			} else {
+				psc.PodSummary[string(podUID)].MemorySwapCurrentBytes = uint64Ptr(0)
 			}
 		}
 		podSummaryList = append(podSummaryList, *psc.PodSummary[string(podUID)])
@@ -545,6 +550,11 @@ func cadvisorInfoToSwapStats(info *cadvisorapiv2.ContainerInfo) *statsapi.SwapSt
 		if !IsMemoryUnlimited(info.Spec.Memory.SwapLimit) {
 			swapAvailableBytes := info.Spec.Memory.SwapLimit - cstat.Memory.Swap
 			swapStats.SwapAvailableBytes = &swapAvailableBytes
+		}
+	} else {
+		swapStats = &statsapi.SwapStats{
+			Time:           metav1.NewTime(cstat.Timestamp),
+			SwapUsageBytes: uint64Ptr(0),
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

since we rely on swap usage bytes, we expect a default value of 0 to be returned from cadvisor client.

nil check was missing in the cadvisor stats handler with regards to swap usage bytes. Only working set bytes were checked.