### PR TITLE
Adding self taint toleration for wasp-agent deployment

### DIFF
--- a/manifests/openshift/ds.yaml
+++ b/manifests/openshift/ds.yaml
@@ -56,6 +56,9 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: wasp
       terminationGracePeriodSeconds: 5
+      tolerations:
+        - effect: NoSchedule
+          key: waspEvictionTaint
       volumes:
         - hostPath:
             path: /

--- a/pkg/taints/taints.go
+++ b/pkg/taints/taints.go
@@ -1,0 +1,85 @@
+package taints
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/openshift-virtualization/wasp-agent/pkg/client"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	WaspTaint = "waspEvictionTaint"
+)
+
+func GenerateTaint() v1.Taint {
+	return v1.Taint{
+		Key:    WaspTaint,
+		Effect: v1.TaintEffectNoSchedule,
+	}
+}
+
+func GenerateToleration() v1.Toleration {
+	return v1.Toleration{
+		Key:    WaspTaint,
+		Effect: v1.TaintEffectNoSchedule,
+	}
+}
+
+func NodeHasEvictionTaint(node *v1.Node) bool {
+	// Check if the node has the specified taint
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == WaspTaint && taint.Effect == v1.TaintEffectNoSchedule {
+			return true
+		}
+	}
+	return false
+}
+
+func AddWaspEvictionTaint(waspCli client.WaspClient, node *v1.Node) error {
+
+	taints := append(node.Spec.Taints, GenerateTaint())
+
+	taintsPatch, err := json.Marshal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"taints": taints,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal taints patch: %v", err)
+	}
+
+	_, err = waspCli.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.StrategicMergePatchType, taintsPatch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch node: %v", err)
+	}
+
+	return nil
+}
+
+func RemoveWaspEvictionTaint(waspCli client.WaspClient, node *v1.Node) error {
+	var newTaints []v1.Taint
+	for _, taint := range node.Spec.Taints {
+		if taint.Key != WaspTaint {
+			newTaints = append(newTaints, taint)
+		}
+	}
+
+	taintsPatch, err := json.Marshal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"taints": newTaints,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal taints patch: %v", err)
+	}
+
+	_, err = waspCli.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.StrategicMergePatchType, taintsPatch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch node: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/wasp/resources/operator/operator.go
+++ b/pkg/wasp/resources/operator/operator.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"fmt"
+	"github.com/openshift-virtualization/wasp-agent/pkg/taints"
 
 	"github.com/openshift-virtualization/wasp-agent/pkg/monitoring/rules"
 	utils2 "github.com/openshift-virtualization/wasp-agent/pkg/util"
@@ -170,6 +171,9 @@ func createWaspDaemonSet(namespace, swapUtilizationTHresholdFactor, maxAverageSw
 	container.Env = createDaemonSetEnvVar(swapUtilizationTHresholdFactor, maxAverageSwapInPagesPerSecond, maxAverageSwapOutPagesPerSecond, averageWindowSizeSeconds, verbosity)
 
 	labels := resources.WithLabels(map[string]string{"name": "wasp"}, utils2.DaemonSetLabels)
+	tolerations := []corev1.Toleration{}
+	tolerations = append(tolerations, taints.GenerateToleration())
+
 	ds := &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSet",
@@ -220,6 +224,7 @@ func createWaspDaemonSet(namespace, swapUtilizationTHresholdFactor, maxAverageSw
 						},
 					},
 					PriorityClassName: "system-node-critical",
+					Tolerations:       tolerations,
 				},
 			},
 			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

When node is under pressure and we evict pods, we also taint the node. If for some reason wasp-agent would be restarted, the wasp-agent pod won't be able to run on a tainted node. 

This is bad since wasp-agent needs to complete the eviction process, and clear the taint as far as node resources are stable again.

