### PR TITLE
[manifests]: fix machine configs for openshift deployment

### DIFF
--- a/manifests/openshift/machineconfig-add-swap.yaml
+++ b/manifests/openshift/machineconfig-add-swap.yaml
@@ -14,6 +14,7 @@ spec:
             [Unit]
             Description=Provision and enable swap
             ConditionFirstBoot=no
+            ConditionPathExists=!/var/tmp/swapfile
             
             [Service]
             Type=oneshot
@@ -22,10 +23,22 @@ spec:
             sudo chmod 600 /var/tmp/swapfile && \
             sudo mkswap /var/tmp/swapfile && \
             sudo swapon /var/tmp/swapfile && \
-            free -h && \
-            sudo systemctl set-property --runtime system.slice MemorySwapMax=0 IODeviceLatencyTargetSec=\"/ 50ms\""
+            free -h"
             
             [Install]
             RequiredBy=kubelet-dependencies.target
           enabled: true
           name: swap-provision.service
+        - contents: |
+            [Unit]
+            Description=Restrict swap for system slice
+            ConditionFirstBoot=no
+
+            [Service]
+            Type=oneshot
+            ExecStart=/bin/sh -c "sudo systemctl set-property --runtime system.slice MemorySwapMax=0 IODeviceLatencyTargetSec=\"/ 50ms\""
+
+            [Install]
+            RequiredBy=kubelet-dependencies.target
+          enabled: true
+          name: cgroup-system-slice-config.service


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

there is a problem when user initiates systemd kubelet restart the swap provision service also restarts, that causes failure since the swap file already exists, and no need to provision it again.

In order to fix this added ConditionPathExists to swap provision unit and the unit was divided into two units:
- swap provision unit runs conditionally based on existence of the swap file
- system slice configuration runs unconditionally in separate unit

both units need to be dependent on kubelet: swap provision requires kubelet restart, and system slice configuration needs to be synced with kubelet as well in order to prevent races.