### PR TITLE
manifests: prefer fallocate to allocate swap file

### DIFF
--- a/manifests/openshift/machineconfig-add-swap.yaml
+++ b/manifests/openshift/machineconfig-add-swap.yaml
@@ -19,7 +19,7 @@ spec:
             [Service]
             Type=oneshot
             Environment=SWAP_SIZE_MB=5000
-            ExecStart=/bin/sh -c "sudo dd if=/dev/zero of=/var/tmp/swapfile count=${SWAP_SIZE_MB} bs=1M && \
+            ExecStart=/bin/sh -c "sudo fallocate -l ${SWAP_SIZE_MB}M /var/tmp/swapfile && \
             sudo chmod 600 /var/tmp/swapfile && \
             sudo mkswap /var/tmp/swapfile && \
             sudo swapon /var/tmp/swapfile && \


### PR DESCRIPTION
Some figures:

    > time sudo fallocate -l '31940M' /var/tmp/swapfile

    real	0m0.022s
    user	0m0.005s
    sys	0m0.012s

    > time sudo dd if=/dev/zero of=/var/tmp/swapfile count=31940 bs=1M
    31940+0 records in
    31940+0 records out
    33491517440 bytes (33 GB, 31 GiB) copied, 98.5563 s, 340 MB/s

    real	1m38.583s
    user	0m0.023s
    sys	0m18.622s